### PR TITLE
Fix incorrect rolling hash calculation

### DIFF
--- a/fingerprint/fingerprint.py
+++ b/fingerprint/fingerprint.py
@@ -58,8 +58,8 @@ class Fingerprint(object):
 
     def rolling_hash(self, old_hash, del_char, new_char):
         # more powerful version of rolling hash
-        hash = ((old_hash - guid(del_char) * self.base **
-                 self.kgram_len) + guid(new_char)) * self.base
+        hash = (old_hash - guid(del_char) * self.base **
+                 (self.kgram_len-1)) * self.base + guid(new_char)
         hash = hash % self.modulo
         return hash
 


### PR DESCRIPTION
IMO the rolling hash function is currently incorrect - given string `s` the hash of its second kgram should be the same as the hash of first kgram of `s[1:]`, which was not true